### PR TITLE
Add install alternative via Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,15 @@ wget 'https://github.com/ms-jpq/sad/releases/latest/download/x86_64-unknown-linu
 
 ### Homebrew:
 
-`brew install ms-jpq/sad/sad`
+```
+brew install ms-jpq/sad/sad
+```
+
+### Scoop:
+
+```bash
+scoop install sad
+```
 
 ### Snap Store:
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ wget 'https://github.com/ms-jpq/sad/releases/latest/download/x86_64-unknown-linu
 
 ### Homebrew:
 
-```
+```bash
 brew install sad
 ```
 


### PR DESCRIPTION
Add installation option via Scoop for Windows (added as https://github.com/ScoopInstaller/Main/issues/4111).
Fixes #193.