### PR TITLE
docs: update homebrew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ wget 'https://github.com/ms-jpq/sad/releases/latest/download/x86_64-unknown-linu
 
 ### Homebrew:
 
-`brew install ms-jpq/sad/sad`
+`brew install sad`
 
 ### Snap Store:
 


### PR DESCRIPTION
Now it has been included into the [core tap](https://formulae.brew.sh/formula/sad), would be nice featured in the docs.