### PR TITLE
Add usage hint for fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export GIT_PAGER='<highlighter-of-your-choice>'
 # ^ can be done in your bash/zsh/rc file.
 find "$FIND_ARGS" | sad '<pattern>' '<replacement>'
 ```
+Note: `--multi` is passed to fzf so you can select multiple files with `Shift+tab` 
 
 **without fzf**
 


### PR DESCRIPTION
I tried to add --fzf '-m' and was wondering why it fails. Had to look into code to see it is already passed. Hopefully, the next one will be spared :)